### PR TITLE
Fix issue where height would sometimes be 1 pixel less than given "exact dimensions".

### DIFF
--- a/js/load-image-scale.js
+++ b/js/load-image-scale.js
@@ -158,8 +158,15 @@
         (minHeight || destHeight) / destHeight
       )
       if (scale > 1) {
-        destWidth *= scale
-        destHeight *= scale
+        /**
+         * These value are used to create canvas elements. Ensuring that they are integers
+         * (rather than floats) avoids a potential 1px rounding error in the canvas element
+         * as canvas elements will always round it down to the nearest integer rather than
+         * following standard rounding rules. For example, using a value of 199.9999999px
+         * for a canvas height would result in a height of 199px rather than 200px.
+         */
+        destWidth = Math.round(destWidth * scale)
+        destHeight = Math.round(destHeight * scale)
       }
     }
     /**
@@ -171,8 +178,15 @@
         (maxHeight || destHeight) / destHeight
       )
       if (scale < 1) {
-        destWidth *= scale
-        destHeight *= scale
+        /**
+         * These value are used to create canvas elements. Ensuring that they are integers
+         * (rather than floats) avoids a potential 1px rounding error in the canvas element
+         * as canvas elements will always round it down to the nearest integer rather than
+         * following standard rounding rules. For example, using a value of 199.9999999px
+         * for a canvas height would result in a height of 199px rather than 200px.
+         */
+        destWidth = Math.round(destWidth * scale)
+        destHeight = Math.round(destHeight * scale)
       }
     }
     if (useCanvas) {


### PR DESCRIPTION
# Context

🆘  Help Scout: https://secure.helpscout.net/conversation/2268495404/49870?folderId=3808239

# Summary

We got a bug report within GPFUP that image heights were always 1 pixel less than specified "exact height" when cropping was enabled.

The folllowing settings result in an image with dimensions `300x249` instead of `300x250`.

<img width="345" alt="image" src="https://github.com/gravitywiz/JavaScript-Load-Image/assets/21110659/7e0fbb6d-092f-4eeb-a8bb-ea72f6478325">


This was happening because the `scaleDown()` function was setting `destHeight` to a float. This float was then passed into [`loadImage.createCanvas(width, height, offscreen)`](
https://github.com/gravitywiz/JavaScript-Load-Image/blob/master/js/load-image-scale.js#L30-L38). The created canvas element would then `floor()` the floating point `height` argument and thus cause the final image to be 1 pixel too short.

For example, notice that the height in the following log output is `249.99999999999997`:

<img width="447" alt="image" src="https://github.com/gravitywiz/JavaScript-Load-Image/assets/21110659/57be1844-f6e9-44a0-b098-64ec5159400d">

In this case, the canvas element will get a height of `249` as only whole numbers are accepted for canvas heights and thus the `249.99999999999997` will get floored.

With this code change, the height is rounded so that the width and height are always integers which _should_ result in correct canvas sizing:

<img width="390" alt="image" src="https://github.com/gravitywiz/JavaScript-Load-Image/assets/21110659/1b843080-6ab8-410b-bd39-cd1037288343">


